### PR TITLE
fix typo in comments of _ThresholdCrossingMarker

### DIFF
--- a/old_bird_detector_redux.py
+++ b/old_bird_detector_redux.py
@@ -251,7 +251,7 @@ class _ThresholdCrossingMarker(_SignalProcessor):
         y[x > self._threshold] = 1
         y[x < 1. / self._threshold] = -2
         
-        # Take differences to mark where the input crosses thr threshold
+        # Take differences to mark where the input crosses the threshold
         # and its inverse. The four types of crossing will be marked as
         # follows:
         #


### PR DESCRIPTION
Here is a minor fix of a typo in the comments of _ThresholdCrossingMarker in old_bird_detector_redux.py

I have a question: if x goes from above threshold to below threshold inverse, the derivative is
-2 - 1 = -3
Likewise, if x goes from below threshold inverse to above threshold, the derivative is
1 - (-2) = 3
These cases don't seem to be addressed in _get_crossings.